### PR TITLE
use PyYAML's SafeLoader explicitly

### DIFF
--- a/clrypt/encdir.py
+++ b/clrypt/encdir.py
@@ -31,7 +31,7 @@ class EncryptedDirectory(object):
     def read_yaml_file(self, group, name, ext='yaml'):
         """Read the named file as decrypted YAML."""
         import yaml
-        return yaml.load(self.read_file(group, name, ext=ext))
+        return yaml.safe_load(self.read_file(group, name, ext=ext))
 
     def write_file(self, in_fp, group, name, ext='yaml'):
         """Encrypt and write the contents of a file-like object to the named file."""


### PR DESCRIPTION
background: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

suppresses these warnings:
```
/Users/ryan/color/color/local/virtualenv3/src/clrypt/clrypt/encdir.py:34: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```