### PR TITLE
[python 3.7] switch from yaml.load() to yaml.full_load()

### DIFF
--- a/clrypt/encdir.py
+++ b/clrypt/encdir.py
@@ -31,7 +31,7 @@ class EncryptedDirectory(object):
     def read_yaml_file(self, group, name, ext='yaml'):
         """Read the named file as decrypted YAML."""
         import yaml
-        return yaml.load(self.read_file(group, name, ext=ext))
+        return yaml.full_load(self.read_file(group, name, ext=ext))
 
     def write_file(self, in_fp, group, name, ext='yaml'):
         """Encrypt and write the contents of a file-like object to the named file."""


### PR DESCRIPTION
PyYAML deprecated yaml.load() in 5.1 since it uses a loader that allows arbitrary code execution. full_load() supports the full YAML syntax but won't execute arbitrary code.

background: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
CVE: https://nvd.nist.gov/vuln/detail/CVE-2017-18342

also see color/color#19212