### PR TITLE
Fix dependencies in clrypt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,15 @@
 [tool.poetry]
 name = "clrypt"
-version = "0.2.3"
+version = "0.2.4"
 description = "A tool to encrypt/decrypt files."
 authors = ["Color Health"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.8"
-future = "0.16.0"
+python = "^3.6"
+future = ">=0.16.0"
 PyYAML = ">=3.11"
-pyasn1 = "0.1.9"
+pyasn1 = ">=0.1.9"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"


### PR DESCRIPTION
Loosen the requirements for installing `clrypt`. This will allow it to be installed in `color/color` without errors.

Is it safe? Well we've been running it in the other repo with `pyasn1==0.4.2`.

Hasn't been an issue yet because we never actually started using the poetry-ized version.